### PR TITLE
feature #22 複数人の参加者をサポートする

### DIFF
--- a/blackjack.rb
+++ b/blackjack.rb
@@ -42,7 +42,7 @@ class Blackjack
     sleep SLEEP_SECOND
 
     # アクション選択を繰り返す処理
-    @table.repeated_decide(@table.player)
+    @table.players.each { |player| @table.repeated_decide(player) }
 
     "dealer"
   end
@@ -64,16 +64,20 @@ class Blackjack
   end
 
   def attribute_win_lose_phase
-    result = @table.determine_winner(@table.player)
-    if result[:is_bust]
-      puts result[:message]
-    else
-      puts "#{@table.player.name}の得点は#{@table.calculate_score(@table.player)}点でした。"
-      puts "ディーラーの得点は#{@table.calculate_score(@table.dealer)}点でした。"
-      puts result[:message]
-    end
+    results = @table.players.reduce([]) { |array, player| array.push(@table.determine_winner(player)) }
+
+    notice_result(results)
     sleep SLEEP_SECOND
     "end"
+  end
+
+  def notice_result(results)
+    puts "ディーラーの得点は#{@table.calculate_score(@table.dealer)}点でした。"
+    sleep SLEEP_SECOND
+    results.each do |result|
+      puts result[:message]
+      sleep SLEEP_SECOND
+    end
   end
 end
 

--- a/part_class/person/cpu.rb
+++ b/part_class/person/cpu.rb
@@ -10,6 +10,7 @@ class CPU < Person
 
   def decide_action(up_card_score)
     score_call
+    sleep SLEEP_SECOND
     if hands.has_A?
       soft_hand_decide(up_card_score)
     else

--- a/part_class/person/dealer.rb
+++ b/part_class/person/dealer.rb
@@ -20,7 +20,7 @@ class Dealer < Person
   end
 
   def get_up_card_score
-    score = hands.hands[0].number
+    score = hands.hands[0].rank
     if score == 1
       11
     else

--- a/part_class/table.rb
+++ b/part_class/table.rb
@@ -3,15 +3,22 @@
 require_relative "../config/application.rb"
 require_relative "./person/dealer.rb"
 require_relative "./person/player.rb"
+require_relative "./person/cpu.rb"
 require_relative "./deck.rb"
 
 class Table
-  attr_reader :dealer, :player
+  attr_reader :dealer, :players
   def initialize
     @dealer = Dealer.new
-    @player = Player.new
+    @players = create_players(3)
     @deck = Deck.new
     @deck.shuffle_deck
+  end
+
+  def create_players(number)
+    players = [Player.new]
+    1.upto(number) { |num| players.push(CPU.new(num)) }
+    players
   end
 
   def deal_out_card(person)
@@ -21,38 +28,47 @@ class Table
   def initial_deal
     1.upto(2) do |num|
       @dealer.initial_receive(@deck.deal_out)
-      deal_out_card(@player)
+      players.each do |player|
+        deal_out_card(player)
+      end
     end
   end
 
   def repeated_decide(person)
     while true
-      if person.decide_action == "Hit"
+      decide = person.is_a?(CPU) ? person.decide_action(dealer.get_up_card_score) : person.decide_action
+
+      unless person.is_a?(Player)
+        puts decide
+        sleep SLEEP_SECOND
+      end
+
+      if decide == "Hit"
         deal_out_card(person)
 
         break if person.state == "bust"
       else
         break
       end
-      sleep SLEEP_SECOND
     end
   end
 
+  # personがdealerに勝利したのかを返す。またその勝敗にbustが関係しているのかを返す。
   def determine_winner(person)
     person_score = calculate_score(person)
     dealer_score = calculate_score(@dealer)
     # personがbustしてpersonの負け
     if person.is_bust?
-      { winner: @dealer, is_bust: true, message: "#{person.name}はbustしました。#{person.name}の負けです。" }
+      { is_winner: false, is_bust: true, message: "#{person.name}はbustしました。#{person.name}の負けです。" }
     # dealerがbustしてpersonの勝ち
     elsif @dealer.is_bust?
-      { winner: person, is_bust: true, message: "#{@dealer.name}はbustしました。#{person.name}の勝ちです！" }
+      { is_winner: true, is_bust: true, message: "#{@dealer.name}はbustしました。#{person.name}の勝ちです！" }
     # 双方bustせず点数比較でpersonが勝ち
     elsif person_score > dealer_score
-      { winner: person, is_bust: false, message: "#{person.name}の勝ちです。" }
+      { is_winner: true, is_bust: false, message: "#{person.name}の得点は#{person_score}点でした。#{person.name}の勝ちです。" }
     # 点数比較でdealerが勝ち
     elsif person_score < dealer_score
-      { winner: @dealer, is_bust: false, message: "#{person.name}の負けです。" }
+      { is_winner: false, is_bust: false, message: "#{person.name}の得点は#{person_score}点でした。#{person.name}の負けです。" }
     # 引き分け
     else
       { winner: nil, is_bust: false, message: "#{person.name}と#{@dealer.name}は同じ点数でした。引き分けです。" }


### PR DESCRIPTION
複数人のプレイヤー参加に対応する #22

ゲームの参加者を人間1人CPU3体の計4名に増やす。
複数人に対応させる。

そのためにtableの変数playerをplayer[]のplayersへ変更
そのたいくつかのメソッドでループを導入してplayersへの処理に対応させた。